### PR TITLE
Fix exaggerated springing in recorded animations.

### DIFF
--- a/Assets/Scripts/DynamicBone/Scripts/DynamicBone.cs
+++ b/Assets/Scripts/DynamicBone/Scripts/DynamicBone.cs
@@ -174,6 +174,12 @@ public class DynamicBone : MonoBehaviour
 #else
             float dt = Time.deltaTime;
 #endif
+
+            if (dt > (1f / 30f))
+            {
+                dt = (1f / 30f);
+            }
+
             UpdateDynamicBones(dt);
         }
     }
@@ -287,11 +293,11 @@ public class DynamicBone : MonoBehaviour
         {
             if (m_UpdateRate > 0)
             {
-                timeVar = Time.deltaTime * m_UpdateRate;
+                timeVar = t * m_UpdateRate;
             }
             else
             {
-                timeVar = Time.deltaTime;
+                timeVar = t;
             }
         }
         else

--- a/Assets/Scripts/Screenshot.cs
+++ b/Assets/Scripts/Screenshot.cs
@@ -111,11 +111,11 @@ public class Screenshot : MonoBehaviour
     {
         ScreenshotSettings.SequenceButton.GetComponentInChildren<TMPro.TextMeshProUGUI>().text = "Recording...";
         string folderName = string.Format("UmaViewer_{0}", DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss-fff"));
-    #if UNITY_ANDROID && !UNITY_EDITOR
+#if UNITY_ANDROID && !UNITY_EDITOR
         string fileDirectory = Application.persistentDataPath + "/../Screenshots/" + folderName;
-    #else
+#else
         string fileDirectory = Application.dataPath + "/../Screenshots/" + folderName;
-    #endif
+#endif
         Directory.CreateDirectory(fileDirectory);
 
         var camera = GetActiveCamera();

--- a/Assets/Scripts/Screenshot.cs
+++ b/Assets/Scripts/Screenshot.cs
@@ -138,12 +138,15 @@ public class Screenshot : MonoBehaviour
             yield return new WaitForEndOfFrame();
             var tex = GrabFrame(camera, width, height, transparent);
             var bytes = tex.EncodeToPNG();
+            Destroy(tex);
 
             var fileName = $"{fileDirectory}/{frame.ToString().PadLeft(maxNameLength, '0')}.png";
-            File.WriteAllBytes(fileName, bytes);
 
-            Destroy(tex);
+            System.Threading.Tasks.Task.Run(() => File.WriteAllBytes(fileName, bytes));
+
             frame++;
+
+            yield return null;
         }
 
         recording = false;


### PR DESCRIPTION
Clamps delta time to the length of a single 30 FPS frame and PNG saving is now asynchronous.